### PR TITLE
Continuous deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,21 +16,21 @@ services:
     - docker
 
 before_install:
-    - docker build -t mkenney/npm:travis-ci .
+    - docker build -t mkenney/npm:ci-build .
     - cd test
 
 script:
-    - docker run --rm -t -i -v $(pwd):/src:rw mkenney/npm:travis-ci /run-as-user /usr/local/bin/bower --version
-    - docker run --rm -t -i -v $(pwd):/src:rw mkenney/npm:travis-ci /run-as-user /usr/local/bin/grunt --version
-    - docker run --rm -t -i -v $(pwd):/src:rw mkenney/npm:travis-ci /run-as-user /usr/local/bin/gulp --version
-    - docker run --rm -t -i -v $(pwd):/src:rw mkenney/npm:travis-ci /run-as-user /usr/local/bin/node --version
-    - docker run --rm -t -i -v $(pwd):/src:rw mkenney/npm:travis-ci /run-as-user /usr/local/bin/npm --version
-    - docker run --rm -t -i -v $(pwd):/src:rw mkenney/npm:travis-ci /run-as-user /usr/local/bin/npm install
+    - docker run --rm -t -i -v $(pwd):/src:rw mkenney/npm:ci-build /run-as-user /usr/local/bin/bower --version
+    - docker run --rm -t -i -v $(pwd):/src:rw mkenney/npm:ci-build /run-as-user /usr/local/bin/grunt --version
+    - docker run --rm -t -i -v $(pwd):/src:rw mkenney/npm:ci-build /run-as-user /usr/local/bin/gulp --version
+    - docker run --rm -t -i -v $(pwd):/src:rw mkenney/npm:ci-build /run-as-user /usr/local/bin/node --version
+    - docker run --rm -t -i -v $(pwd):/src:rw mkenney/npm:ci-build /run-as-user /usr/local/bin/npm --version
+    - docker run --rm -t -i -v $(pwd):/src:rw mkenney/npm:ci-build /run-as-user /usr/local/bin/npm install
     - ls node_modules
-    - docker run --rm -t -i -v $(pwd):/src:rw mkenney/npm:travis-ci /run-as-user /usr/local/bin/bower install
+    - docker run --rm -t -i -v $(pwd):/src:rw mkenney/npm:ci-build /run-as-user /usr/local/bin/bower install
     - ls bower_components
-    - docker run --rm -t -i -v $(pwd):/src:rw mkenney/npm:travis-ci /run-as-user /usr/local/bin/grunt
-    - docker run --rm -t -i -v $(pwd):/src:rw mkenney/npm:travis-ci /run-as-user /usr/local/bin/gulp
+    - docker run --rm -t -i -v $(pwd):/src:rw mkenney/npm:ci-build /run-as-user /usr/local/bin/grunt
+    - docker run --rm -t -i -v $(pwd):/src:rw mkenney/npm:ci-build /run-as-user /usr/local/bin/gulp
 
 after_success:
     - cd ../ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,3 +30,7 @@ script:
     - ls bower_components
     - docker run --rm -t -i -v $(pwd):/src:rw mkenney/npm:travis-ci /run-as-user /usr/local/bin/grunt
     - docker run --rm -t -i -v $(pwd):/src:rw mkenney/npm:travis-ci /run-as-user /usr/local/bin/gulp
+
+after_success:
+    - cd ../ci
+    - sh ./deploy.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ branches:
     only:
         - master
         - alpine
+        - continuous-deployment
 
 notifications:
     slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ branches:
     only:
         - master
         - alpine
-        - continuous-deployment
 
 notifications:
     slack:

--- a/README.md
+++ b/README.md
@@ -73,6 +73,14 @@ If you need additional modules and/or wrapper scripts [let me know](https://gith
 
 ## Change log
 
+### 2016-07-13
+
+I have re-structured automated the Docker Hub builds, they are no longer triggered by GitHub pushes. Instead they are triggered by a deployment script that is executed on successful `travis-ci` builds. This way, even if builds are failing the image on DockerHub should remain the last stable image at all times.
+
+There may be an issue with API call throttling on the Docker Hub side, if that seems to be happening I'll dig in further.
+
+Please [let me know](https://github.com/mkenney/docker-phpunit/issues) if you have any problems.
+
 ### 2016-07-05
 
 Fixed a string-comparison issue on logins where the default shell is Bourne shell rather than Bourne again shell.

--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+
+echo "Triggering builds for branch '$TRAVIS_BRANCH'"
+curl -H "Content-Type: application/json" --data "{\"source_type\": \"Branch\", \"source_name\": \"$TRAVIS_BRANCH\"}" -X POST https://registry.hub.docker.com/u/mkenney/npm/trigger/$DOCKER_TOKEN/


### PR DESCRIPTION
Changing DockerHub automated builds to be triggered on successful travis-ci builds rather than git pushes.
