### PR TITLE
Added --no-check-certficate to scripts

### DIFF
--- a/bin/bower
+++ b/bin/bower
@@ -5,7 +5,7 @@ BRANCH=master
 
 if [ "self-update" = "$1" ]; then
     docker pull mkenney/npm:$TAG
-    wget -nv -O $0 https://raw.githubusercontent.com/mkenney/docker-npm/$BRANCH/bin/bower && exit 0
+    wget -nv --no-check-certficate -O $0 https://raw.githubusercontent.com/mkenney/docker-npm/$BRANCH/bin/bower && exit 0
 else
     docker run --rm -t -i -v $(pwd):/src:rw -v $HOME/.ssh:/home/dev/.ssh:ro mkenney/npm:$TAG /run-as-user /usr/local/bin/bower $@
 fi

--- a/bin/grunt
+++ b/bin/grunt
@@ -5,7 +5,7 @@ BRANCH=master
 
 if [ "self-update" = "$1" ]; then
     docker pull mkenney/npm:$TAG
-    wget -nv -O $0 https://raw.githubusercontent.com/mkenney/docker-npm/$BRANCH/bin/grunt && exit 0
+    wget -nv --no-check-certficate -O $0 https://raw.githubusercontent.com/mkenney/docker-npm/$BRANCH/bin/grunt && exit 0
 else
     docker run --rm -t -i -v $(pwd):/src:rw mkenney/npm:$TAG /run-as-user /usr/local/bin/grunt $@
 fi

--- a/bin/gulp
+++ b/bin/gulp
@@ -5,7 +5,7 @@ BRANCH=master
 
 if [ "self-update" = "$1" ]; then
     docker pull mkenney/npm:$TAG
-    wget -nv -O $0 https://raw.githubusercontent.com/mkenney/docker-npm/$BRANCH/bin/gulp && exit 0
+    wget -nv --no-check-certficate -O $0 https://raw.githubusercontent.com/mkenney/docker-npm/$BRANCH/bin/gulp && exit 0
 else
     docker run --rm -t -i -v $(pwd):/src:rw mkenney/npm:$TAG /run-as-user /usr/local/bin/gulp $@
 fi

--- a/bin/node
+++ b/bin/node
@@ -5,7 +5,7 @@ BRANCH=master
 
 if [ "self-update" = "$1" ]; then
     docker pull mkenney/npm:$TAG
-    wget -nv -O $0 https://raw.githubusercontent.com/mkenney/docker-npm/$BRANCH/bin/node && exit 0
+    wget -nv --no-check-certficate -O $0 https://raw.githubusercontent.com/mkenney/docker-npm/$BRANCH/bin/node && exit 0
 else
     docker run --rm -t -i -v $(pwd):/src:rw mkenney/npm:$TAG /run-as-user /usr/local/bin/node $@
 fi

--- a/bin/npm
+++ b/bin/npm
@@ -5,7 +5,7 @@ BRANCH=master
 
 if [ "self-update" = "$1" ]; then
     docker pull mkenney/npm:$TAG
-    wget -nv -O $0 https://raw.githubusercontent.com/mkenney/docker-npm/$BRANCH/bin/npm && exit 0
+    wget -nv --no-check-certficate -O $0 https://raw.githubusercontent.com/mkenney/docker-npm/$BRANCH/bin/npm && exit 0
 else
     docker run --rm -t -i -v $(pwd):/src:rw -v $HOME/.ssh:/home/dev/.ssh:ro mkenney/npm:$TAG /run-as-user /usr/local/bin/npm $@
 fi


### PR DESCRIPTION
I added --no-check-certficate to the scripts, there may be a better solution but I get this error when I try to run self-update

```
ERROR: cannot verify raw.githubusercontent.com's certificate, issued by `/C=US/O=DigiCert Inc/OU=www.digicert.com/CN=DigiCert SHA2 High Assurance Server CA':
  Unable to locally verify the issuer's authority.
ERROR: certificate common name `www.github.com' doesn't match requested host name `raw.githubusercontent.com'.
To connect to raw.githubusercontent.com insecurely, use `--no-check-certificate'.
```
