### PR TITLE
Keep make and g++ after build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -100,11 +100,8 @@ RUN set -x \
 
     && apk del \
         curl \
-        gcc \
-        g++ \
         gnupg \
         linux-headers \
-        make \
         paxctl \
         python \
         tar \


### PR DESCRIPTION
I.e. npm need them to build node-sass
