### PR TITLE
Revert "Keep make and g++ after build"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -100,8 +100,11 @@ RUN set -x \
 
     && apk del \
         curl \
+        gcc \
+        g++ \
         gnupg \
         linux-headers \
+        make \
         paxctl \
         python \
         tar \


### PR DESCRIPTION
Reverts mkenney/docker-npm#9

The change makes the image much larger, so reverting
