### PR TITLE
Remove run-as-user command because it is also the entrypoint

### DIFF
--- a/bin/bower
+++ b/bin/bower
@@ -16,5 +16,5 @@ else
     else
         term_type=i
     fi
-    docker run --rm -$term_type -v $(pwd):/src:rw -v $HOME/.ssh:/home/dev/.ssh:ro mkenney/npm:$TAG /run-as-user /usr/local/bin/$SCRIPT --allow-root $@
+    docker run --rm -$term_type -v $(pwd):/src:rw -v $HOME/.ssh:/home/dev/.ssh:ro mkenney/npm:$TAG /usr/local/bin/$SCRIPT --allow-root $@
 fi

--- a/bin/generate-md
+++ b/bin/generate-md
@@ -16,5 +16,5 @@ else
     else
         term_type=i
     fi
-    docker run --rm -$term_type -v $(pwd):/src:rw -v $HOME/.ssh:/home/dev/.ssh:ro mkenney/npm:$TAG /run-as-user /usr/local/bin/$SCRIPT $@
+    docker run --rm -$term_type -v $(pwd):/src:rw -v $HOME/.ssh:/home/dev/.ssh:ro mkenney/npm:$TAG /usr/local/bin/$SCRIPT $@
 fi

--- a/bin/grunt
+++ b/bin/grunt
@@ -16,5 +16,5 @@ else
     else
         term_type=i
     fi
-    docker run --rm -$term_type -v $(pwd):/src:rw -v $HOME/.ssh:/home/dev/.ssh:ro mkenney/npm:$TAG /run-as-user /usr/local/bin/$SCRIPT $@
+    docker run --rm -$term_type -v $(pwd):/src:rw -v $HOME/.ssh:/home/dev/.ssh:ro mkenney/npm:$TAG /usr/local/bin/$SCRIPT $@
 fi

--- a/bin/gulp
+++ b/bin/gulp
@@ -16,5 +16,5 @@ else
     else
         term_type=i
     fi
-    docker run --rm -$term_type -v $(pwd):/src:rw -v $HOME/.ssh:/home/dev/.ssh:ro mkenney/npm:$TAG /run-as-user /usr/local/bin/$SCRIPT $@
+    docker run --rm -$term_type -v $(pwd):/src:rw -v $HOME/.ssh:/home/dev/.ssh:ro mkenney/npm:$TAG /usr/local/bin/$SCRIPT $@
 fi

--- a/bin/node
+++ b/bin/node
@@ -16,5 +16,5 @@ else
     else
         term_type=i
     fi
-    docker run --rm -$term_type -v $(pwd):/src:rw -v $HOME/.ssh:/home/dev/.ssh:ro mkenney/npm:$TAG /run-as-user /usr/local/bin/$SCRIPT $@
+    docker run --rm -$term_type -v $(pwd):/src:rw -v $HOME/.ssh:/home/dev/.ssh:ro mkenney/npm:$TAG /usr/local/bin/$SCRIPT $@
 fi

--- a/bin/npm
+++ b/bin/npm
@@ -16,5 +16,5 @@ else
     else
         term_type=i
     fi
-    docker run --rm -$term_type -v $(pwd):/src:rw -v $HOME/.ssh:/home/dev/.ssh:ro mkenney/npm:$TAG /run-as-user /usr/local/bin/$SCRIPT $@
+    docker run --rm -$term_type -v $(pwd):/src:rw -v $HOME/.ssh:/home/dev/.ssh:ro mkenney/npm:$TAG /usr/local/bin/$SCRIPT $@
 fi

--- a/bin/yarn
+++ b/bin/yarn
@@ -16,5 +16,5 @@ else
     else
         term_type=i
     fi
-    docker run --rm -$term_type -v $(pwd):/src:rw -v $HOME/.ssh:/home/dev/.ssh:ro mkenney/npm:$TAG /run-as-user /usr/local/bin/$SCRIPT $@
+    docker run --rm -$term_type -v $(pwd):/src:rw -v $HOME/.ssh:/home/dev/.ssh:ro mkenney/npm:$TAG /usr/local/bin/$SCRIPT $@
 fi

--- a/test/bower.sh
+++ b/test/bower.sh
@@ -6,7 +6,7 @@ if [ "" != "$1" ]; then
     IMAGE_TAG=$1
 fi
 
-CMD="docker run --rm -ti -v $PROJECT_PATH/test/resources:/src:rw mkenney/npm:$IMAGE_TAG /run-as-user /usr/local/bin/bower  --allow-root"
+CMD="docker run --rm -ti -v $PROJECT_PATH/test/resources:/src:rw mkenney/npm:$IMAGE_TAG /usr/local/bin/bower  --allow-root"
 
 cd $PROJECT_PATH/test/resources
 rm -rf bower_components

--- a/test/grunt.sh
+++ b/test/grunt.sh
@@ -6,8 +6,8 @@ if [ "" != "$1" ]; then
     IMAGE_TAG=$1
 fi
 
-NPM="docker run --rm -ti -v $PROJECT_PATH/test/resources:/src:rw mkenney/npm:$IMAGE_TAG /run-as-user /usr/local/bin/npm"
-CMD="docker run --rm -ti -v $PROJECT_PATH/test/resources:/src:rw mkenney/npm:$IMAGE_TAG /run-as-user /usr/local/bin/grunt"
+NPM="docker run --rm -ti -v $PROJECT_PATH/test/resources:/src:rw mkenney/npm:$IMAGE_TAG /usr/local/bin/npm"
+CMD="docker run --rm -ti -v $PROJECT_PATH/test/resources:/src:rw mkenney/npm:$IMAGE_TAG /usr/local/bin/grunt"
 
 cd $PROJECT_PATH/test/resources
 rm -rf node_modules

--- a/test/gulp.sh
+++ b/test/gulp.sh
@@ -6,8 +6,8 @@ if [ "" != "$1" ]; then
     IMAGE_TAG=$1
 fi
 
-NPM="docker run --rm -ti -v $PROJECT_PATH/test/resources:/src:rw mkenney/npm:$IMAGE_TAG /run-as-user /usr/local/bin/npm"
-CMD="docker run --rm -ti -v $PROJECT_PATH/test/resources:/src:rw mkenney/npm:$IMAGE_TAG /run-as-user /usr/local/bin/gulp"
+NPM="docker run --rm -ti -v $PROJECT_PATH/test/resources:/src:rw mkenney/npm:$IMAGE_TAG /usr/local/bin/npm"
+CMD="docker run --rm -ti -v $PROJECT_PATH/test/resources:/src:rw mkenney/npm:$IMAGE_TAG /usr/local/bin/gulp"
 
 cd $PROJECT_PATH/test/resources
 rm -rf node_modules

--- a/test/md.sh
+++ b/test/md.sh
@@ -6,7 +6,7 @@ if [ "" != "$1" ]; then
     IMAGE_TAG=$1
 fi
 
-CMD="docker run --rm -ti -v $PROJECT_PATH/test/resources:/src:rw mkenney/npm:$IMAGE_TAG /run-as-user /usr/local/bin/generate-md"
+CMD="docker run --rm -ti -v $PROJECT_PATH/test/resources:/src:rw mkenney/npm:$IMAGE_TAG /usr/local/bin/generate-md"
 
 cd $PROJECT_PATH/test/resources
 rm -rf html

--- a/test/node.sh
+++ b/test/node.sh
@@ -6,7 +6,7 @@ if [ "" != "$1" ]; then
     IMAGE_TAG=$1
 fi
 
-CMD="docker run --rm -ti -v $PROJECT_PATH/test/resources:/src:rw mkenney/npm:$IMAGE_TAG /run-as-user /usr/local/bin/node"
+CMD="docker run --rm -ti -v $PROJECT_PATH/test/resources:/src:rw mkenney/npm:$IMAGE_TAG /usr/local/bin/node"
 
 output=`$CMD --version`
 result=$?

--- a/test/npm.sh
+++ b/test/npm.sh
@@ -6,7 +6,7 @@ if [ "" != "$1" ]; then
     IMAGE_TAG=$1
 fi
 
-CMD="docker run --rm -ti -v $PROJECT_PATH/test/resources:/src:rw mkenney/npm:$IMAGE_TAG /run-as-user /usr/local/bin/npm"
+CMD="docker run --rm -ti -v $PROJECT_PATH/test/resources:/src:rw mkenney/npm:$IMAGE_TAG /usr/local/bin/npm"
 
 cd $PROJECT_PATH/test/resources
 rm -rf node_modules

--- a/test/yarn.sh
+++ b/test/yarn.sh
@@ -6,7 +6,7 @@ if [ "" != "$1" ]; then
     IMAGE_TAG=$1
 fi
 
-CMD="docker run --rm -ti -v $PROJECT_PATH/test/resources:/src:rw mkenney/npm:$IMAGE_TAG /run-as-user /usr/local/bin/yarn"
+CMD="docker run --rm -ti -v $PROJECT_PATH/test/resources:/src:rw mkenney/npm:$IMAGE_TAG /usr/local/bin/yarn"
 
 cd $PROJECT_PATH/test/resources
 rm -rf node_modules


### PR DESCRIPTION
I found that when using the provided shell scripts the docker container fails to run the desired command. Instead the command that is send to the container is:

`
/run-as-user /run-as-user /usr/local/bin/{script} [...]`

I was able to see with 'top' that the above was the command which was running without ever finishing. Removing the /run-as-user from the shell scripts worked for me.