### PR TITLE
Support a configuration file

### DIFF
--- a/bin/bower
+++ b/bin/bower
@@ -1,14 +1,23 @@
 #!/usr/bin/env sh
 
+CONFIG_FILE=".docker-npm"
+if [ -f "$CONFIG_FILE" ]; then
+    . "./$CONFIG_FILE"
+fi
+
+DEFAULT_IMAGE_NAME=mkenney/npm
+IMAGE_NAME=${DOCKER_NPM_IMAGE_NAME-$DEFAULT_IMAGE_NAME}
+
 TAG=node-11-alpine
 if [ "" != "$DOCKER_NPM_TAG" ]; then
     TAG="$DOCKER_NPM_TAG"
 fi
+
 SCRIPT=bower
 INSTALL_SCRIPT=https://raw.githubusercontent.com/mkenney/docker-npm/master/bin/install.sh
 
 if [ "self-update" = "$1" ]; then
-    docker pull mkenney/npm:$TAG
+    docker pull $IMAGE_NAME:$TAG
     curl -f -L -s $INSTALL_SCRIPT | sh -s $SCRIPT $(dirname $0) && exit 0
 else
     if [ -t 0 ]; then
@@ -23,5 +32,5 @@ else
         -v $HOME/.ssh:/home/dev/.ssh:ro \
         -v $HOME/.npm:/home/dev/.npm:rw \
         $DOCKER_NPM_ARGS \
-        mkenney/npm:$TAG /usr/local/bin/$SCRIPT --allow-root $@
+        $IMAGE_NAME:$TAG /usr/local/bin/$SCRIPT --allow-root $@
 fi

--- a/bin/generate-md
+++ b/bin/generate-md
@@ -1,14 +1,23 @@
 #!/usr/bin/env sh
 
+CONFIG_FILE=".docker-npm"
+if [ -f "$CONFIG_FILE" ]; then
+    . "./$CONFIG_FILE"
+fi
+
+DEFAULT_IMAGE_NAME=mkenney/npm
+IMAGE_NAME=${DOCKER_NPM_IMAGE_NAME-$DEFAULT_IMAGE_NAME}
+
 TAG=node-11-alpine
 if [ "" != "$DOCKER_NPM_TAG" ]; then
     TAG="$DOCKER_NPM_TAG"
 fi
+
 SCRIPT=generate-md
 INSTALL_SCRIPT=https://raw.githubusercontent.com/mkenney/docker-npm/master/bin/install.sh
 
 if [ "self-update" = "$1" ]; then
-    docker pull mkenney/npm:$TAG
+    docker pull $IMAGE_NAME:$TAG
     curl -f -L -s $INSTALL_SCRIPT | sh -s $SCRIPT $TAG $(dirname $0)
 else
     if [ -t 0 ]; then
@@ -23,5 +32,5 @@ else
         -v $HOME/.ssh:/home/dev/.ssh:ro \
         -v $HOME/.npm:/home/dev/.npm:rw \
         $DOCKER_NPM_ARGS \
-        mkenney/npm:$TAG /usr/local/bin/$SCRIPT $@
+        $IMAGE_NAME:$TAG /usr/local/bin/$SCRIPT $@
 fi

--- a/bin/grunt
+++ b/bin/grunt
@@ -1,14 +1,23 @@
 #!/usr/bin/env sh
 
+CONFIG_FILE=".docker-npm"
+if [ -f "$CONFIG_FILE" ]; then
+    . "./$CONFIG_FILE"
+fi
+
+DEFAULT_IMAGE_NAME=mkenney/npm
+IMAGE_NAME=${DOCKER_NPM_IMAGE_NAME-$DEFAULT_IMAGE_NAME}
+
 TAG=node-11-alpine
 if [ "" != "$DOCKER_NPM_TAG" ]; then
     TAG="$DOCKER_NPM_TAG"
 fi
+
 SCRIPT=grunt
 INSTALL_SCRIPT=https://raw.githubusercontent.com/mkenney/docker-npm/master/bin/install.sh
 
 if [ "self-update" = "$1" ]; then
-    docker pull mkenney/npm:$TAG
+    docker pull $IMAGE_NAME:$TAG
     curl -f -L -s $INSTALL_SCRIPT | sh -s $SCRIPT $TAG $(dirname $0)
 else
     if [ -t 0 ]; then
@@ -23,5 +32,5 @@ else
         -v $HOME/.ssh:/home/dev/.ssh:ro \
         -v $HOME/.npm:/home/dev/.npm:rw \
         $DOCKER_NPM_ARGS \
-        mkenney/npm:$TAG /usr/local/bin/$SCRIPT $@
+        $IMAGE_NAME:$TAG /usr/local/bin/$SCRIPT $@
 fi

--- a/bin/gulp
+++ b/bin/gulp
@@ -1,14 +1,23 @@
 #!/usr/bin/env sh
 
+CONFIG_FILE=".docker-npm"
+if [ -f "$CONFIG_FILE" ]; then
+    . "./$CONFIG_FILE"
+fi
+
+DEFAULT_IMAGE_NAME=mkenney/npm
+IMAGE_NAME=${DOCKER_NPM_IMAGE_NAME-$DEFAULT_IMAGE_NAME}
+
 TAG=node-11-alpine
 if [ "" != "$DOCKER_NPM_TAG" ]; then
     TAG="$DOCKER_NPM_TAG"
 fi
+
 SCRIPT=gulp
 INSTALL_SCRIPT=https://raw.githubusercontent.com/mkenney/docker-npm/master/bin/install.sh
 
 if [ "self-update" = "$1" ]; then
-    docker pull mkenney/npm:$TAG
+    docker pull $IMAGE_NAME:$TAG
     curl -f -L -s $INSTALL_SCRIPT | sh -s $SCRIPT $TAG $(dirname $0)
 else
     if [ -t 0 ]; then
@@ -23,5 +32,5 @@ else
         -v $HOME/.ssh:/home/dev/.ssh:ro \
         -v $HOME/.npm:/home/dev/.npm:rw \
         $DOCKER_NPM_ARGS \
-        mkenney/npm:$TAG /usr/local/bin/$SCRIPT $@
+        $IMAGE_NAME:$TAG /usr/local/bin/$SCRIPT $@
 fi

--- a/bin/node
+++ b/bin/node
@@ -1,14 +1,23 @@
 #!/usr/bin/env sh
 
+CONFIG_FILE=".docker-npm"
+if [ -f "$CONFIG_FILE" ]; then
+    . "./$CONFIG_FILE"
+fi
+
+DEFAULT_IMAGE_NAME=mkenney/npm
+IMAGE_NAME=${DOCKER_NPM_IMAGE_NAME-$DEFAULT_IMAGE_NAME}
+
 TAG=node-11-alpine
 if [ "" != "$DOCKER_NPM_TAG" ]; then
     TAG="$DOCKER_NPM_TAG"
 fi
+
 SCRIPT=node
 INSTALL_SCRIPT=https://raw.githubusercontent.com/mkenney/docker-npm/master/bin/install.sh
 
 if [ "self-update" = "$1" ]; then
-    docker pull mkenney/npm:$TAG
+    docker pull $IMAGE_NAME:$TAG
     curl -f -L -s $INSTALL_SCRIPT | sh -s $SCRIPT $TAG $(dirname $0)
 else
     if [ -t 0 ]; then
@@ -23,5 +32,5 @@ else
         -v $HOME/.ssh:/home/dev/.ssh:ro \
         -v $HOME/.npm:/home/dev/.npm:rw \
         $DOCKER_NPM_ARGS \
-        mkenney/npm:$TAG /usr/local/bin/$SCRIPT $@
+        $IMAGE_NAME:$TAG /usr/local/bin/$SCRIPT $@
 fi

--- a/bin/npm
+++ b/bin/npm
@@ -1,14 +1,23 @@
 #!/usr/bin/env sh
 
+CONFIG_FILE=".docker-npm"
+if [ -f "$CONFIG_FILE" ]; then
+    . "./$CONFIG_FILE"
+fi
+
+DEFAULT_IMAGE_NAME=mkenney/npm
+IMAGE_NAME=${DOCKER_NPM_IMAGE_NAME-$DEFAULT_IMAGE_NAME}
+
 TAG=node-11-alpine
 if [ "" != "$DOCKER_NPM_TAG" ]; then
     TAG="$DOCKER_NPM_TAG"
 fi
+
 SCRIPT=npm
 INSTALL_SCRIPT=https://raw.githubusercontent.com/mkenney/docker-npm/master/bin/install.sh
 
 if [ "self-update" = "$1" ]; then
-    docker pull mkenney/npm:$TAG
+    docker pull $IMAGE_NAME:$TAG
     curl -f -L -s $INSTALL_SCRIPT | sh -s $SCRIPT $TAG $(dirname $0)
 else
     if [ -t 0 ]; then
@@ -23,5 +32,5 @@ else
         -v $HOME/.ssh:/home/dev/.ssh:ro \
         -v $HOME/.npm:/home/dev/.npm:rw \
         $DOCKER_NPM_ARGS \
-        mkenney/npm:$TAG /usr/local/bin/$SCRIPT $@
+        $IMAGE_NAME:$TAG /usr/local/bin/$SCRIPT $@
 fi

--- a/bin/npx
+++ b/bin/npx
@@ -1,14 +1,23 @@
 #!/usr/bin/env sh
 
+CONFIG_FILE=".docker-npm"
+if [ -f "$CONFIG_FILE" ]; then
+    . "./$CONFIG_FILE"
+fi
+
+DEFAULT_IMAGE_NAME=mkenney/npm
+IMAGE_NAME=${DOCKER_NPM_IMAGE_NAME-$DEFAULT_IMAGE_NAME}
+
 TAG=node-11-alpine
 if [ "" != "$DOCKER_NPM_TAG" ]; then
     TAG="$DOCKER_NPM_TAG"
 fi
+
 SCRIPT=npx
 INSTALL_SCRIPT=https://raw.githubusercontent.com/mkenney/docker-npm/master/bin/install.sh
 
 if [ "self-update" = "$1" ]; then
-    docker pull mkenney/npm:$TAG
+    docker pull $IMAGE_NAME:$TAG
     curl -f -L -s $INSTALL_SCRIPT | sh -s $SCRIPT $TAG $(dirname $0)
 else
     if [ -t 0 ]; then
@@ -23,5 +32,5 @@ else
         -v $HOME/.ssh:/home/dev/.ssh:ro \
         -v $HOME/.npm:/home/dev/.npm:rw \
         $DOCKER_NPM_ARGS \
-        mkenney/npm:$TAG /usr/local/bin/$SCRIPT $@
+        $IMAGE_NAME:$TAG /usr/local/bin/$SCRIPT $@
 fi

--- a/bin/yarn
+++ b/bin/yarn
@@ -1,14 +1,23 @@
 #!/usr/bin/env sh
 
+CONFIG_FILE=".docker-npm"
+if [ -f "$CONFIG_FILE" ]; then
+    . "./$CONFIG_FILE"
+fi
+
+DEFAULT_IMAGE_NAME=mkenney/npm
+IMAGE_NAME=${DOCKER_NPM_IMAGE_NAME-$DEFAULT_IMAGE_NAME}
+
 TAG=node-11-alpine
 if [ "" != "$DOCKER_NPM_TAG" ]; then
     TAG="$DOCKER_NPM_TAG"
 fi
+
 SCRIPT=yarn
 INSTALL_SCRIPT=https://raw.githubusercontent.com/mkenney/docker-npm/master/bin/install.sh
 
 if [ "self-update" = "$1" ]; then
-    docker pull mkenney/npm:$TAG
+    docker pull $IMAGE_NAME:$TAG
     curl -f -L -s $INSTALL_SCRIPT | sh -s $SCRIPT $TAG $(dirname $0)
 else
     if [ -t 0 ]; then
@@ -22,5 +31,5 @@ else
         -v $HOME/.ssh:/home/dev/.ssh:ro \
         -v $HOME/.npm:/home/dev/.npm:rw \
         $DOCKER_NPM_ARGS \
-        mkenney/npm:$TAG /usr/local/bin/$SCRIPT $@
+        $IMAGE_NAME:$TAG /usr/local/bin/$SCRIPT $@
 fi


### PR DESCRIPTION
If a `.docker-npm` file is present in the current directory, it will be imported.

This can be used to define these environment variables:

- `DOCKER_NPM_IMAGE_NAME`: Base name of the Docker image. Default: `mkenney/npm`.
- `DOCKER_NPM_TAG`: Docker image tag. Default specified in script code e.g. `node-11-alpine`.

Use cases:

- `DOCKER_NPM_TAG` can be used to "pin" a project to a given node version.
- `DOCKER_NPM_IMAGE_NAME` can be used to optionally decouple the scripts from the default `mkenney/npm` image, e.g. for experimenting with newer node versions.

Example:

```
❯ cat .docker-npm 
export DOCKER_NPM_IMAGE_NAME=fernando
export DOCKER_NPM_TAG=node-12-alpine
```